### PR TITLE
fix: Fix bug where any frontmatter value containing a colon gets cropped (#17)

### DIFF
--- a/src/updateKeyInFrontMatter.ts
+++ b/src/updateKeyInFrontMatter.ts
@@ -18,7 +18,7 @@ ${content}`;
 
   const oldMatterSplitted = maybeFrontMatter
     .split('\n')
-    .map((item) => item.split(/: /, 2));
+    .map((item) => item.split(/: /));
 
   const maybeKeyIndex = oldMatterSplitted.findIndex(
     (it) => it[0] === key && it.length === 2,


### PR DESCRIPTION
Fix issue #17. I encountered this problem as well and this seems to be the issue. I think it is fixed now, and shouldn't affect the other functionality.