### PR TITLE
Check for existance of ExcalidrawAutomate

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,7 @@ export default class UpdateTimeOnSavePlugin extends Plugin {
     }
 
     //@ts-ignore
-    const ea: any = ExcalidrawAutomate; //ea will be undefined if the Excalidraw plugin is not running
+    const ea: any = typeof ExcalidrawAutomate === "undefined" ? undefined : ExcalidrawAutomate; //ea will be undefined if the Excalidraw plugin is not running
     const isExcalidrawFile = ea ? ea.isExcalidrawFile(file) : false;
 
     if (isExcalidrawFile) {


### PR DESCRIPTION
If the plugin is not installed, the following error occurs: "ReferenceError: ExcalidrawAutomate is not defined at UpdateTimeOnSavePlugin.handleFileChange"