### PR TITLE
Fix broken canvas creation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -65,12 +65,12 @@ export default class UpdateTimeOnSavePlugin extends Plugin {
     if (!file.path) {
       return true;
     }
-    if (file.extension != "md") {
+    if (file.extension != 'md') {
       return true;
     }
     // Canvas files are created as 'Canvas.md',
     // so the plugin will update "frontmatter" and break the file when it gets created
-    if(file.name == "Canvas.md")
+    if(file.name == 'Canvas.md')
     {
       return true;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,13 @@ export default class UpdateTimeOnSavePlugin extends Plugin {
     if (!file.path) {
       return true;
     }
-    if (!file.path.endsWith('.md')) {
+    if (file.extension != "md") {
+      return true;
+    }
+    // Canvas files are created as 'Canvas.md',
+    // so the plugin will update "frontmatter" and break the file when it gets created
+    if(file.name == "Canvas.md")
+    {
       return true;
     }
 


### PR DESCRIPTION
Added additional check to prevent modifying canvas files during their creation.

Canvas files appear to be created as `Canvas.md` and renamed to `Canvas.canvas` after the fact. However, the plugin updates the file's "frontmatter" during creation, which makes the file invalid.

Also use `file.extension` instead of `endsWith`.